### PR TITLE
switch to micromamba image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           environment-name: suprashare
 
       - name: Run tests
+        shell: bash -l {0}
         run: |
           pytest -v 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Conda setup
-        uses: uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/provision-with-micromamba@main
         with:
           cache-env: true
           micromamba-version: 0.23.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,25 +19,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Conda setup
-        uses: s-weigand/setup-conda@v1
+        uses: uses: mamba-org/provision-with-micromamba@main
         with:
-          update-conda: true
+          cache-env: true
+          micromamba-version: 0.23.0
+          environment-file: environment.yml
 
-      # cache the conda installation to speedup CI runs
-      - uses: actions/cache@v2
-        id: cache
-        with:
-          path: /usr/share/miniconda/envs/suprashare
-          key: ${{ runner.os }}-conda-cache-${{ hashFiles('environment.yml') }}
-          
-      - name: Conda environment creation
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          conda env create -f environment.yml
-          source activate suprashare
       - name: Run tests
         run: |
-          source activate suprashare
           pytest -v 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           cache-env: true
           micromamba-version: 0.23.0
+          environment-name: suprashare
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           cache-env: true
           micromamba-version: 0.23.0
-          environment-file: environment.yml
 
       - name: Run tests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM continuumio/miniconda3
+FROM mambaorg/micromamba:0.23.0
 
-RUN conda update conda
-COPY environment.yml .
-RUN conda env create -f environment.yml
-
-# Make RUN commands use the new env
-SHELL ["conda", "run", "-n", "suprashare", "/bin/bash", "-c"]
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml
+RUN micromamba install -y -f /tmp/environment.yml && \
+    micromamba clean --all --yes
 
 COPY . ./
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: suprashare
+name: base
 channels: 
   - conda-forge
 dependencies:


### PR DESCRIPTION
Nice suggestion @AdrianDAlessandro - This cuts down the build time and final image size both by somewhere between 2x and 3x. It also means we are installing into the base environment, so don't need to mess around to use specific conda environment within Docker.

closes #15 