### PR TITLE
Change publish action to use GitHub Container Registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
           source activate suprashare
           pytest -v 
 
-
   publish:
     if: github.ref == 'refs/heads/main'
     needs: test
@@ -50,17 +49,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         
-      - name: Login to GitHub Docker Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          
+
+      - name: Get image metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+
       - name: Build and push Docker image
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
-          context: .
           push: true
-          tags: docker.pkg.github.com/imperialcollegelondon/suprashare/suprashare:${{ github.sha }}, docker.pkg.github.com/imperialcollegelondon/suprashare/suprashare:latest
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This updates to use the GitHub Container Registry and also the repo metadata to automatically generate the image tag / location so it has permission to build the repo, unlike here: https://github.com/ImperialCollegeLondon/cage-prediction-webapp/runs/6772909655?check_suite_focus=true#step:4:747 